### PR TITLE
feat: support fullscreen in embedded contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Polytrack
 Polytrack is a racing game based off of Trackmania. The game is developed by Kodub and is active on Itch.io. This is version 0.4 of Polytrack, and new updates will not be posted because I am lazy.
+
+## Fullscreen embedding
+
+When Polytrack is embedded inside another site (such as Google Sites) the browser may block fullscreen requests from the game. The `fullscreen.js` module now attempts to request fullscreen using vendor-prefixed APIs and falls back to posting a `fullscreen-request` message to the parent window if the request is denied. A host page may listen for this message and trigger fullscreen on behalf of the game, matching the behaviour of YouTube embeds.


### PR DESCRIPTION
## Summary
- allow fullscreen with vendor-prefixed APIs and fallback to parent `postMessage`
- handle fullscreen state messages and document embedding requirements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c05446f97c8329af0d612bf46d4f06