### PR TITLE
feat: support fullscreen in embedded contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # Polytrack
 Polytrack is a racing game based off of Trackmania. The game is developed by Kodub and is active on Itch.io. This is version 0.4 of Polytrack, and new updates will not be posted because I am lazy.
+
+## Fullscreen embedding
+
+When Polytrack is embedded inside another site (such as Google Sites) the browser may block fullscreen requests from the game. The `fullscreen.js` module now attempts to request fullscreen using vendor-prefixed APIs and, if denied, posts a message identical to the one sent by YouTube players:
+
+```
+{"event":"command","func":"toggleFullscreen","args":[]}
+```
+
+Google Sites already listens for this message and will enter fullscreen on behalf of the embed. The game also listens for the matching `infoDelivery` message from the parent to reflect fullscreen state in its UI.

--- a/fullscreen.js
+++ b/fullscreen.js
@@ -3,18 +3,66 @@ const button = document.getElementById('fullscreen-btn');
 
 function toggleFullscreen() {
   if (!document.fullscreenElement) {
-    document.documentElement.requestFullscreen();
+    const el = document.documentElement;
+    const request =
+      el.requestFullscreen ||
+      el.webkitRequestFullscreen ||
+      el.mozRequestFullScreen ||
+      el.msRequestFullscreen;
+
+    if (request) {
+      try {
+        const result = request.call(el);
+        if (result && typeof result.catch === 'function') {
+          result.catch(() => {
+            sendYoutubeStyleRequest();
+          });
+        }
+      } catch (e) {
+        sendYoutubeStyleRequest();
+      }
+    } else {
+      sendYoutubeStyleRequest();
+    }
   } else {
-    document.exitFullscreen();
+    const exit =
+      document.exitFullscreen ||
+      document.webkitExitFullscreen ||
+      document.mozCancelFullScreen ||
+      document.msExitFullscreen;
+    if (exit) {
+      exit.call(document);
+    }
+  }
+}
+
+function sendYoutubeStyleRequest() {
+  if (window !== window.parent) {
+    const message = JSON.stringify({
+      event: 'command',
+      func: 'toggleFullscreen',
+      args: []
+    });
+    window.parent.postMessage(message, '*');
   }
 }
 
 button.addEventListener('click', toggleFullscreen);
 
 document.addEventListener('fullscreenchange', () => {
-  if (document.fullscreenElement) {
-    controls.style.display = 'none';
-  } else {
-    controls.style.display = 'flex';
+  controls.style.display = document.fullscreenElement ? 'none' : 'flex';
+});
+
+window.addEventListener('message', (event) => {
+  let data = event.data;
+  if (typeof data === 'string') {
+    try {
+      data = JSON.parse(data);
+    } catch (_) {
+      data = null;
+    }
+  }
+  if (data && data.event === 'infoDelivery' && data.info && 'fullscreen' in data.info) {
+    controls.style.display = data.info.fullscreen ? 'none' : 'flex';
   }
 });


### PR DESCRIPTION
## Summary
- emulate YouTube's fullscreen messaging for Google Sites compatibility
- parse `infoDelivery` messages to track fullscreen state from the parent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c05446f97c8329af0d612bf46d4f06